### PR TITLE
Don't allow user to carry a dwarf

### DIFF
--- a/adventure/game.py
+++ b/adventure/game.py
@@ -847,6 +847,8 @@ class Game(Data):
             self.t_carry(verb, objs[0])
 
     def t_carry(self, verb, obj):  #9010
+        if obj is self.dwarf:
+            return self.write_message(13)
         if obj.is_toting:
             self.write(verb.default_message)
             self.finish_turn()

--- a/adventure/game.py
+++ b/adventure/game.py
@@ -848,7 +848,7 @@ class Game(Data):
 
     def t_carry(self, verb, obj):  #9010
         if obj is self.dwarf:
-            return self.write_message(13)
+            return self.dont_understand()
         if obj.is_toting:
             self.write(verb.default_message)
             self.finish_turn()

--- a/adventure/tests/vignettes.txt
+++ b/adventure/tests/vignettes.txt
@@ -273,6 +273,16 @@ THERE ARE BARS OF SILVER HERE!
 >>> game.lamp_turns
 35
 
+We should not be able to pick up a dwarf!
+
+>>> restart(room=75, dwarves=True, randoms=(.05,.05,.05,.05,.05,.05))
+>>> game.dwarf_stage = 3
+>>> for _dwarf in game.dwarves:
+...     _dwarf.room = game.rooms[75]
+>>> take(dwarf)
+I DON'T UNDERSTAND THAT!
+<BLANKLINE>
+
 ----------------------------------
 Making sure that hints are offered
 ----------------------------------

--- a/adventure/tests/vignettes.txt
+++ b/adventure/tests/vignettes.txt
@@ -275,7 +275,7 @@ THERE ARE BARS OF SILVER HERE!
 
 We should not be able to pick up a dwarf! (#21)
 
->>> restart(room=75, dwarves=True, randoms=(.05,.05,.05,.05,.05,.05))
+>>> restart(room=75, dwarves=True, randoms=(.05,.05,.05,.05,.05,.05,.3))
 >>> game.dwarf_stage = 3
 >>> for _dwarf in game.dwarves:
 ...     _dwarf.room = game.rooms[75]

--- a/adventure/tests/vignettes.txt
+++ b/adventure/tests/vignettes.txt
@@ -273,7 +273,7 @@ THERE ARE BARS OF SILVER HERE!
 >>> game.lamp_turns
 35
 
-We should not be able to pick up a dwarf!
+We should not be able to pick up a dwarf! (#21)
 
 >>> restart(room=75, dwarves=True, randoms=(.05,.05,.05,.05,.05,.05))
 >>> game.dwarf_stage = 3


### PR DESCRIPTION
Resolves #21 

Instead of going through the code and rewriting some of the base `dwarf` vs. `dwarves` confusion that I outlined in #21, this PR simply checks if the object we are attempting to carry is a dwarf, and if it is, displays the `dont_understand` error message.