### PR TITLE
Fixed AttributeError: 'Game' object has no attribute 't_walk'

### DIFF
--- a/adventure/game.py
+++ b/adventure/game.py
@@ -837,6 +837,7 @@ class Game(Data):
     t_fee = write_default_message
     t_brief = write_default_message
     t_hours = write_default_message
+    t_walk = write_default_message
 
     def i_carry(self, verb):  #8010
         is_dwarf_here = any( dwarf.room == self.loc for dwarf in self.dwarves )


### PR DESCRIPTION
There is an error that crashes the game when there is an item either in the room or already in inventory and a walk-style verb is used (i.e., WALK, RUN, TRAVE, GO, PROCE, CONTI, EXPLO, GOTO, FOLLO, TURN). For example, entering "lamp turn" or "keys turn" results in the runtime error: **AttributeError: 'Game' object has no attribute 't_walk'**. This pull request fixes that issue.