### PR TITLE
Fix: 'Object' object has no attribute 'text'

### DIFF
--- a/adventure/game.py
+++ b/adventure/game.py
@@ -541,6 +541,9 @@ class Game(Data):
 
         if word1 == 'say':
             return self.t_say(word1, word2) if word2 else self.i_say(word1)
+        
+        if word2 == 'say':
+            return self.t_say(word2, word1)     
 
         kinds = (word1.kind, word2.kind if word2 else None)
 


### PR DESCRIPTION
There is an error that crashes the game when there is an item either in the room or already in inventory and a say-style verb is used (i.e., SAY, CHANT, SING, UTTER, MUMBL). For example, "lamp say" results in the runtime error: **AttributeError: 'Object' object has no attribute 'text'**. This pull request fixes that issue.